### PR TITLE
Update windows_compilation.md

### DIFF
--- a/introduction/windows_compilation.md
+++ b/introduction/windows_compilation.md
@@ -59,7 +59,7 @@ pacman -S git make zip gcc patch
 ```
  - Compile the radare2:
 ```sh
-./configure ; make ; make w32dist
+./configure --with-ostype=windows ; make ; make w32dist
 ```
 ### Bindings
 

--- a/introduction/windows_compilation.md
+++ b/introduction/windows_compilation.md
@@ -55,7 +55,7 @@ pacman -Su
 ```
  - Install the building essentials:
 ```sh
-pacman -S git make zip gcc
+pacman -S git make zip gcc patch
 ```
  - Compile the radare2:
 ```sh


### PR DESCRIPTION
1) "patch" MSYS2 package is needed to build r2.
2) "./configure" on MSYS2 must be run with "./configure --with-ostype=windows"