### PR TITLE
Fix r2 tip about '-A'

### DIFF
--- a/crackmes/avatao/01-reverse4/first_steps.md
+++ b/crackmes/avatao/01-reverse4/first_steps.md
@@ -60,7 +60,7 @@ asm we trust!
 [0x00400720]>
 ```
 
-> ***r2 tip:*** The -A switch runs *aa* command at start to analyze all
+> ***r2 tip:*** The -A switch runs *aaa* command at start to analyze all
 > referenced code, so we will have functions, strings, XREFS, etc. right at the
 > beginning. As usual, you can get help with *?*.
 


### PR DESCRIPTION
"r2 -A ./binaryFile", -A  flag is executing `aaa` and not `aa`