### PR TITLE
Remove MSIL from being mentioned as it's no longer supported

### DIFF
--- a/introduction/overview.md
+++ b/introduction/overview.md
@@ -14,7 +14,7 @@ A program to extract information from executable binaries, such as ELF, PE, Java
 
 ### rasm2
 
-A command line assembler and disassembler for multiple architectures (including Intel x86 and x86-64, MIPS, ARM, PowerPC, Java, and MSIL).
+A command line assembler and disassembler for multiple architectures (including Intel x86 and x86-64, MIPS, ARM, PowerPC and Java).
 
 #### Examples
 

--- a/rasm2/intro.md
+++ b/rasm2/intro.md
@@ -50,7 +50,6 @@ Plugins for supported target architectures can be listed with the `-L` option. K
     _d  32         malbolge    LGPL3   Malbolge Ternary VM
     ad  32 64      mips        GPL3    MIPS CPU
     _d  16 32 64   mips.cs     BSD     Capstone MIPS disassembler
-    _d  16 32 64   msil        PD      .NET Microsoft Intermediate Language
     _d  32         nios2       GPL3    NIOS II Embedded Processor
     _d  32 64      ppc         GPL3    PowerPC
     _d  32 64      ppc.cs      BSD     Capstone PowerPC disassembler


### PR DESCRIPTION
As mentioned in #59 MSIL removed from overview and `rasm2` intro.