### PR TITLE
Fix rarun2 description in overview part

### DIFF
--- a/introduction/overview.md
+++ b/introduction/overview.md
@@ -93,11 +93,11 @@ A launcher for running programs within different environments, with different ar
        $ cat foo.rr2
        #!/usr/bin/rarun2
        program=./pp400
-       arg0=10
+       arg1=10
        stdin=foo.txt
        chdir=/tmp
        #chroot=.
-       ./foo.rr2
+       $ rarun2 ./foo.rr2
 
 
 #### Connecting a Program to a Socket


### PR DESCRIPTION
[PDF: radare2book](https://www.gitbook.com/download/pdf/book/radare/radare2book) page 11

change

```
       $ cat foo.rr2
       #!/usr/bin/rarun2
       program=./pp400
       arg0=10                    ---- Fix: arg0 -> arg1
       stdin=foo.txt
       chdir=/tmp
       #chroot=.
       ./foo.rr2                  ---- Fix: $ rarun2 ./foo.rr2
```

to

```
       $ cat foo.rr2
       #!/usr/bin/rarun2
       program=./pp400
       arg1=10
       stdin=foo.txt
       chdir=/tmp
       #chroot=.
       $ rarun2 ./foo.rr2
```