### PR TITLE
Updated 'o' section

### DIFF
--- a/basic_commands/mapping_files.md
+++ b/basic_commands/mapping_files.md
@@ -9,30 +9,32 @@ Mapping files is done using the `o` (open) command. Let's read the help:
 
     [0x00000000]> o?
     |Usage: o [com- ] [file] ([offset])
-    | o                    list opened files
-    | oq                   list all open files
-    | o*                   list opened files in r2 commands
-    | o=                   list opened files (ascii-art bars)
-    | ob[?] [lbdos] [...]  list opened binary files backed by fd
-    | oc [file]            open core file, like relaunching r2
-    | oi[-|idx]            alias for o, but using index instead of fd
-    | oj[?]                list opened files in JSON format
-    | oL                   list all IO plugins registered
-    | om[?]                create, list, remove IO maps
-    | on [file] 0x4000     map raw file at 0x4000 (no r_bin involved)
-    | oo[?]                reopen current file (kill+fork in debugger)
-    | oo+                  reopen current file in read-write
-    | ood [args]           reopen in debugger mode (with args)
-    | oo[bnm] [...]        see oo? for help
-    | op [fd]              priorize given fd (see also ob)
-    | o 4                  Switch to open file on fd 4
-    | o-1                  close file descriptor 1
-    | o-*                  close all opened files
-    | o--                  close all files, analysis, binfiles, flags, same as !r2 --
-    | o [file]             open [file] file in read-only
-    | o+ [file]            open file in read-write mode
-    | o [file] 0x4000      map file at 0x4000
-    | ox fd fdx            exchange the descs of fd and fdx and keep the mapping
+    | o                         list opened files
+    | o-1                       close file descriptor 1
+    | o-!*                      close all opened files
+    | o--                       close all files, analysis, binfiles, flags, same as !r2 --
+    | o [file]                  open [file] file in read-only
+    | o+ [file]                 open file in read-write mode
+    | o [file] 0x4000 rwx       map file at 0x4000
+    | oa[-] [A] [B] [filename]  Specify arch and bits for given file
+    | oq                        list all open files
+    | o*                        list opened files in r2 commands
+    | o. [len]                  open a malloc://[len] copying the bytes from current offset
+    | o=                        list opened files (ascii-art bars)
+    | ob[?] [lbdos] [...]       list opened binary files backed by fd
+    | oc [file]                 open core file, like relaunching r2
+    | of [file]                 open file and map it at addr 0 as read-only
+    | oi[-|idx]                 alias for o, but using index instead of fd
+    | oj[?]                     list opened files in JSON format
+    | oL                        list all IO plugins registered
+    | om[?]                     create, list, remove IO maps
+    | on [file] 0x4000          map raw file at 0x4000 (no r_bin involved)
+    | oo[?]                     reopen current file (kill+fork in debugger)
+    | oo+                       reopen current file in read-write
+    | ood[r] [args]             reopen in debugger mode (with args)
+    | oo[bnm] [...]             see oo? for help
+    | op [fd]                   prioritize given fd (see also ob)
+    | ox fd fdx                 exchange the descs of fd and fdx and keep the mapping
 
 Prepare a simple layout:
 


### PR DESCRIPTION
Due to some changes like this one https://github.com/radare/radare2/issues/10022 this section was not up-to-date. PR with the latest 'o' output to match the book with the tool.