### PR TITLE
Get rid of most “etc” occurrences

### DIFF
--- a/analysis/code_analysis.md
+++ b/analysis/code_analysis.md
@@ -6,7 +6,7 @@ Radare have different code analysis techniques implemented in the core and avail
 
 As long as the whole functionalities of r2 are available with the API as well as using commands. This gives you the ability to implement your own analysis loops using any programming language, even with r2 oneliners, shellscripts, or analysis or core native plugins.
 
-The analysis will show up the internal data structures to identify basic blocks, function trees, to extract opcode-level information etc.
+The analysis will show up the internal data structures to identify basic blocks, function trees and to extract opcode-level information.
 
 The most common radare2 analysis command sequence is `aa`, which stands for "analyze all". That all is refering to all symbols and entrypoints. If your binary is stripped you will need to use other commands like aaa, aab, aar, aac or so.
 
@@ -68,7 +68,7 @@ In this example, we analyze the whole file (`aa`) and then print disassembly of 
 The `aa` command belongs to the family of autoanalysis commands and performs only the most basic
 autoanalysis steps. In radare2 there are many different types of the autoanalysis commands with a
 different analysis depth, including partial emulation: `aa`, `aaa`, `aab`, `aaaa`, ...
-There is also a mapping of those commands to the r2 CLI options: `r2 -A`, `r2 -AA`, etc
+There is also a mapping of those commands to the r2 CLI options: `r2 -A`, `r2 -AA`, and so on.
 
 It is a common sense that completely automated analysis can produce non sequitur results, thus
 radare2 provides separate commands for the particular stages of the analysis allowing fine-grained
@@ -254,7 +254,8 @@ There are a few options for this:
 - `anal.limits` - enables the range limits for analysis operations
 - `anal.from` - starting address of the limit range
 - `anal.to` - the corresponding end of the limit range
-- `anal.in` - specify search boundaries for analysis (`io.maps`, `io.sections.exec`, `dbg.maps` etc ...)
+- `anal.in` - specify search boundaries for analysis (`io.maps`, `io.sections.exec`, `dbg.maps` and many
+more - see `e anal.in=?` for the complete list)
 
 ### Jump tables
 

--- a/analysis/intro.md
+++ b/analysis/intro.md
@@ -2,7 +2,7 @@
 
 Radare2 has a very rich set of commands and configuration options to perform data and code analysis,
 to extract useful information from a binary, like pointers, string references,
-basic blocks, opcode data, jump targets, cross references, etc.
+basic blocks, opcode data, jump targets, cross references and much more.
 These operations are handled by the `a` (analyze) command family:
 
 ```
@@ -37,7 +37,7 @@ very different parts of the analysis:
  - Code flow analysis
  - Data references analysis
  - Using loaded symbols
- - Managing different type of graphs, like CFG, call graph, etc
+ - Managing different type of graphs, like CFG and call graph
  - Manage variables
  - Manage types
  - Emulation using ESIL VM

--- a/basic_commands/comparing_bytes.md
+++ b/basic_commands/comparing_bytes.md
@@ -71,7 +71,7 @@ Compare 1/8 equal bytes (0%)
 0x00000002 (byte=03)   4c 'L'  ->  00 ' '
 ```
 
-The number parameter can, of course, be math expressions which use flag names etc:
+The number parameter can, of course, be math expressions which use flag names and anything allowed in an expression:
 
 ```
 [0x00000000]> cx 7f469046

--- a/basic_commands/mapping_files.md
+++ b/basic_commands/mapping_files.md
@@ -8,7 +8,7 @@ Sometimes, we want to rebase a binary, or maybe we want to load or map the file 
 
 When launching r2, the base address can be changed with the -B flag. But you must notice the difference when opening files with unknown headers, like bootloaders, so we need to map them using the -m flag (or specifying it as argument to the o command).
 
-Being able to open files and map portions of them at random places in memory with some attributes like permissions, name, etc. Is the perfect basic tooling to reproduce an environment like a core file, a debug session, by also loading and mapping all the libraries the binary depends.
+Being able to open files and map portions of them at random places in memory specifying attributes like permissions and name. Is the perfect basic tooling to reproduce an environment like a core file, a debug session, by also loading and mapping all the libraries the binary depends.
 
 Opening files (and mapping them) is done using the `o` (open) command. Let's read the help:
 

--- a/basic_commands/seeking.md
+++ b/basic_commands/seeking.md
@@ -2,7 +2,7 @@
 
 To move around the file we are inspecting we will need to change the offset we are using the `s` command.
 
-The argument is a math expression that can contain flag names, parenthesis, addition, substraction, multiplication of immediates of contents of memory using brackets, etc.
+The argument is a math expression that can contain flag names, parenthesis, addition, substraction, multiplication of immediates of contents of memory using brackets.
 
 Some example commands:
 

--- a/basic_commands/types.md
+++ b/basic_commands/types.md
@@ -37,7 +37,7 @@ There are three different methods to define new types:
 
 3. Radare2 also supports loading header files using the command `to` followed by a path to the header file you want to load.
 
-You can View loaded types in r2 using `ts` for structures, `tu` for unions, `tf` for function signatures, etc...
+You can View loaded types in r2 using `ts` for structures, `tu` for unions, `tf` for function signatures, `te` for enums.
 
 You can also cast pointers to data types and view data in there accordingly with `tp`. EX:
 

--- a/configuration/evars.md
+++ b/configuration/evars.md
@@ -72,7 +72,7 @@ This variable specifies the mode for colorized screen output: "false" (or 0) mea
 
 ### scr.seek
 
-This variable accepts an expression, a pointer (eg. eip), etc. If set, radare will set seek position to its value on startup.
+This variable accepts a full-featured expression or a pointer/flag (eg. eip). If set, radare will set seek position to its value on startup.
 
 ### cfg.fortunes
 

--- a/debugger/files.md
+++ b/debugger/files.md
@@ -1,11 +1,11 @@
 # Files
 
-The radare2 debugger allows the user to list and manipulate the filedescriptors from the target process.
+The radare2 debugger allows the user to list and manipulate the file descriptors from the target process.
 
 This is a useful feature, which is not found in other debuggers, the functionality is similar to the lsof command line tool.
 
-But have extra subcommands to change the seek, close them, duplicate, etc,
+But have extra subcommands to change the seek, close or duplicate them.
 
-So, at any time in the debugging session you can replace the stdio filedescriptors to use network sockets created by r2, or replace a network socket connection to hijack it.
+So, at any time in the debugging session you can replace the stdio file descriptors to use network sockets created by r2, or replace a network socket connection to hijack it.
 
-This functionality is also available in r2frida thru by using the dd command prefixed with a backslash. In r2 you may want to see the output of dd? for proper details.
+This functionality is also available in r2frida by using the dd command prefixed with a backslash. In r2 you may want to see the output of dd? for proper details.

--- a/debugger/intro.md
+++ b/debugger/intro.md
@@ -9,7 +9,7 @@ rwd  gdb         Attach to gdbserver, 'qemu -s', gdb://localhost:1234 (LGPL3)
 
 There are different backends for many target architectures and operating systems, e.g., GNU/Linux, Windows, MacOS X, (Net,Free,Open)BSD and Solaris.
 
-Process memory is treated as a plain file. All mapped memory pages of a debugged program and its libraries can be read and interpreted as code, data structures etc.
+Process memory is treated as a plain file. All mapped memory pages of a debugged program and its libraries can be read and interpreted as code or data structures.
 
 Communication between radare and the debugger IO layer is wrapped into `system()` calls, which accept a string as an argument, and executes it as a command. An answer is then buffered in the output console, its contents can be additionally processed by a script. Access to the IO system is achieved with `=!`. Most IO plugins provide help with `=!?` or `=!help`. For example:
 

--- a/disassembling/adding_metadata.md
+++ b/disassembling/adding_metadata.md
@@ -3,7 +3,7 @@
 The typical work involved in reversing binary files makes powerful annotation capabilities essential.
 Radare offers multiple ways to store and retrieve such metadata.
 
-By following common basic UNIX principles, it is easy to write a small utility in a scripting language which uses `objdump`, `otool`, etc. to obtain information from a binary and to import it into radare. For example, take a look at `idc2r.py` shipped with [radare2ida](https://github.com/radare/radare2ida). To use it, invoke it as `idc2r.py file.idc > file.r2`. It reads an IDC file exported from an IDA Pro database and produces an r2 script containing the same comments, names of functions etc. You can import the resulting 'file.r2' by using the dot `.` command of radare:
+By following common basic UNIX principles, it is easy to write a small utility in a scripting language which uses `objdump`, `otool` or any other existing utility to obtain information from a binary and to import it into radare. For example, take a look at `idc2r.py` shipped with [radare2ida](https://github.com/radare/radare2ida). To use it, invoke it as `idc2r.py file.idc > file.r2`. It reads an IDC file exported from an IDA Pro database and produces an r2 script containing the same comments, names of functions and other data. You can import the resulting 'file.r2' by using the dot `.` command of radare:
 ```
 [0x00000000]> . file.r2
 ```

--- a/disassembling/esil.md
+++ b/disassembling/esil.md
@@ -23,7 +23,7 @@ esp -= 4
 4bytes(dword) [esp] = ebp
 ```
 We can see that this corresponds to the x86 instruction `push ebp`! Isn't that cool?
-The aim is to be able to express most of the common operations performed by CPUs, like binary arithmetic operations, memory loads and stores, processing syscalls plus a lot more. This way if we can transform the instructions to ESIL we can see what a program does while it is running even for the most cryptic architectures you definitely don't have a device to debug on for.
+The aim is to be able to express most of the common operations performed by CPUs, like binary arithmetic operations, memory loads and stores, processing syscalls. This way if we can transform the instructions to ESIL we can see what a program does while it is running even for the most cryptic architectures you definitely don't have a device to debug on for.
 
 ## Use ESIL
 

--- a/disassembling/esil.md
+++ b/disassembling/esil.md
@@ -23,7 +23,7 @@ esp -= 4
 4bytes(dword) [esp] = ebp
 ```
 We can see that this corresponds to the x86 instruction `push ebp`! Isn't that cool?
-The aim is to be able to express most of the common operations performed by CPUs, like binary arithmetic operations, memory loads and stores, processing syscalls etc. This way if we can transform the instructions to ESIL we can see what a program does while it is running even for the most cryptic architectures you definitely don't have a device to debug on for.
+The aim is to be able to express most of the common operations performed by CPUs, like binary arithmetic operations, memory loads and stores, processing syscalls plus a lot more. This way if we can transform the instructions to ESIL we can see what a program does while it is running even for the most cryptic architectures you definitely don't have a device to debug on for.
 
 ## Use ESIL
 
@@ -221,7 +221,7 @@ This approach is more readable, but it is less stack-friendly.
 
 NOPs are represented as empty strings. As it was said previously, syscalls are marked by '$' command. For example, '0x80,$'. It delegates emulation from the ESIL machine to a callback which implements syscalls for a specific OS/kernel.
 
-Traps are implemented with the `<code>,TRAP` command. They are used to throw exceptions for invalid instructions, division by zero, memory read error, etc.
+Traps are implemented with the `<code>,TRAP` command. They are used to throw exceptions for invalid instructions, division by zero, memory read error, or any other needed by specific architectures.
 
 ### Quick Analysis
 
@@ -377,7 +377,7 @@ We need a way to retrieve the numeric value of 'rip'. This is a very simple exam
 
 ### API HOOKS
 
-It is important for emulation to be able to setup hooks in parser, so we can extend it to implement analysis without having to change parser again and again. That is, every time an operation is about to be executed, a user hook is called. It can be used to determine if `RIP` is going to change, or if the instruction updates stack, etc.
+It is important for emulation to be able to setup hooks in parser, so we can extend it to implement analysis without having to change parser again and again. That is, every time an operation is about to be executed, a user hook is called. It can be used for example to determine if `RIP` is going to change, or if the instruction updates the stack.
 Later, we can split that callback into several ones to have an event-based analysis API that may be extended in js like this:
 
 ```

--- a/disassembling/intro.md
+++ b/disassembling/intro.md
@@ -2,7 +2,7 @@
 
 Disassembling in radare is just a way to represent an array of bytes. It is handled as a special print mode within `p` command.
 
-In the old times, when the radare core was smaller, the disassembler was handled by an external rsc file. That is, radare first dumped current block into a file, and then simply called `objdump` configured to disassemble for Intel, ARM etc...
+In the old times, when the radare core was smaller, the disassembler was handled by an external rsc file. That is, radare first dumped current block into a file, and then simply called `objdump` configured to disassemble for Intel, ARM or other supported architectures.
 
 It was a working and unix friendly solution, but it was inefficient as it repeated the same expensive actions over and over, because there were no caches. As a result, scrolling was terribly slow.
 
@@ -18,7 +18,7 @@ Or from inside radare2:
 > e asm.arch=??
 ```
 
-This was many years before capstone appeared. So r2 was using udis86 and olly disassemblers, many gnu (from binutils) etc, 
+This was many years before capstone appeared. So r2 was using udis86 and olly disassemblers, many gnu (from binutils).
 
 Nowadays, the disassembler support is one of the basic features of radare. It now has many options, endianness, including target architecture flavor and disassembler variants, among other things.
 

--- a/first_steps/command_format.md
+++ b/first_steps/command_format.md
@@ -28,7 +28,7 @@ pd 2000 | grep eax    ; grep opcodes that use the 'eax' register
 px 20 ; pd 3 ; px 40  ; multiple commands in a single line
 ```
 
-The standard UNIX pipe `|` is also available in the radare2 shell. You can use it to filter the output of an r2 command with a shell program that reads from stdin, such as `grep`, `less`, `wc`, etc. If you do not want to spawn anything, or you can't, or the target system does not have the basic UNIX tools you need (Windows or embedded users), you can also use the built-in grep (`~`).
+The standard UNIX pipe `|` is also available in the radare2 shell. You can use it to filter the output of an r2 command with any shell program that reads from stdin, such as `grep`, `less`, `wc`. If you do not want to spawn anything, or you can't, or the target system does not have the basic UNIX tools you need (Windows or embedded users), you can also use the built-in grep (`~`).
 
 See `?~?` for help.
 

--- a/first_steps/history.md
+++ b/first_steps/history.md
@@ -9,7 +9,7 @@ In 2006, Sergi Alvarez (aka pancake), was working as a forensic analyst. And, by
 
 It was designed to recover a deleted file from an HFS+ partition.
 
-After that, pancake decided to extend the tool to have a pluggable io to be able to attach to processes, implemented the debugger functionalities, support for multiple archs, code analysis, etc..
+After that, pancake decided to extend the tool to have a pluggable io to be able to attach to processes, implemented the debugger functionalities, support for multiple archs and code analysis.
 
 The project has evolved to provide a complete framework for analyzing binaries while making use of basic UNIX concepts. Those concepts include the famous "everything is a file", "small programs that interact using stdin/stdout", and "keep it simple" paradigms.
 

--- a/first_steps/overview.md
+++ b/first_steps/overview.md
@@ -10,7 +10,7 @@ It implements an advanced command line interface for moving around a file, analy
 
 ### rabin2
 
-A program to extract information from executable binaries, such as ELF, PE, Java CLASS, Mach-O, etc. rabin2 is used by the core to get exported symbols, imports, file information, cross references (xrefs), library dependencies, sections, etc.
+A program to extract information from executable binaries, such as ELF, PE, Java CLASS, Mach-O, plus any format supported by r2 plugins. rabin2 is used by the core to get data like exported symbols, imports, file information, cross references (xrefs), library dependencies, sections.
 
 ### rasm2
 
@@ -133,7 +133,7 @@ stdio=/dev/ttys010
 
 ### rax2
 
-A minimalistic mathematical expression evaluator for the shell that is useful for making base conversions between floating point values, hexadecimal representations, hexpair strings to ASCII, octal to integer, etc. It also supports endianness settings and can be used as an interactive shell if no arguments are given.
+A minimalistic mathematical expression evaluator for the shell that is useful for making base conversions between floating point values, hexadecimal representations, hexpair strings to ASCII, octal to integer, and more. It also supports endianness settings and can be used as an interactive shell if no arguments are given.
 
 #### Examples
 

--- a/plugins/ioplugins.md
+++ b/plugins/ioplugins.md
@@ -1,8 +1,8 @@
 # IO plugins
 
-All access to files, network, debugger, etc. is wrapped by an IO abstraction layer that allows radare to treat all data as if it were just a file.
+All access to files, network, debugger and all input/output in general is wrapped by an IO abstraction layer that allows radare to treat all data as if it were just a file.
 
-IO plugins are the ones used to wrap the open, read, write and 'system' on virtual file systems. You can make radare understand anything as a plain file. E.g., a socket connection, a remote radare session, a file, a process, a device, a gdb session, etc..
+IO plugins are the ones used to wrap the open, read, write and 'system' on virtual file systems. You can make radare understand anything as a plain file. E.g. a socket connection, a remote radare session, a file, a process, a device, a gdb session.
 
 So, when radare reads a block of bytes, it is the task of an IO plugin to get these bytes from any place and put them into internal buffer. An IO plugin is chosen by a file's URI to be opened. Some examples:
 

--- a/plugins/python.md
+++ b/plugins/python.md
@@ -171,7 +171,7 @@ There is a special function, which returns information about the file - `info`:
 ```
 
 3. This structure should contain a pointers to the most important functions like
-`check_bytes`, `load` and `load_bytes`, `entries`, `relocs`, `imports`, etc.
+`check_bytes`, `load` and `load_bytes`, `entries`, `relocs`, `imports`.
 
 ```python
     return {

--- a/tools/rabin2/file_identification.md
+++ b/tools/rabin2/file_identification.md
@@ -1,6 +1,6 @@
 ## File Properties Identification
 
-File type identification is done using `-I`. With this option, rabin2 prints information on a binary type, its encoding, endianness, class, operating system, etc.:
+File type identification is done using `-I`. With this option, rabin2 prints information on a binary type, like its encoding, endianness, class, operating system:
 ```
 $ rabin2 -I /bin/ls
 arch     x86

--- a/tools/rabin2/intro.md
+++ b/tools/rabin2/intro.md
@@ -1,7 +1,7 @@
 # Rabin2 — Show Properties of a Binary
 
-Under this bunny-arabic-like name, radare hides a powerful tool to handle binary files, to get information on imports, sections, headers etc. Rabin2 can present it in several formats accepted by other tools, including radare2 itself.
-Rabin2 understands many file formats: Java CLASS, ELF, PE, Mach-O, etc., and it is able to obtain symbol import/exports, library dependencies, strings of data sections, xrefs,  entrypoint address, sections, architecture type.
+Under this bunny-arabic-like name, radare hides a powerful tool to handle binary files, to get information on imports, sections, headers and other data. Rabin2 can present it in several formats accepted by other tools, including radare2 itself.
+Rabin2 understands many file formats: Java CLASS, ELF, PE, Mach-O or any format supported by plugins, and it is able to obtain symbol import/exports, library dependencies, strings of data sections, xrefs,  entrypoint address, sections, architecture type.
 
 ```
 $ rabin2 -h

--- a/tools/rahash2/intro.md
+++ b/tools/rahash2/intro.md
@@ -2,7 +2,7 @@
 
 The rahash2 tool can be used to compute checksums of files, disk devices or strings. By block or entirely using many different hash algorithms.
 
-This tool is also capable of doing some encoding/decoding operations like base64, xor encryptions, etc
+This tool is also capable of doing some encoding/decoding operations like base64 and xor encryption.
 
 This is an example usage:
 

--- a/tools/rarun2/intro.md
+++ b/tools/rarun2/intro.md
@@ -1,7 +1,8 @@
 # Rarun2
 
 Rarun2 is a tool allowing to setup a specified execution environment - redefine stdin/stdout, pipes,
-change the environment variables and other useful settings.
+change the environment variables and other settings useful to craft the boundary conditions you need to run
+a binary for debugging.
 
 ```
 $ rarun2 -h

--- a/tools/rarun2/intro.md
+++ b/tools/rarun2/intro.md
@@ -1,7 +1,7 @@
 # Rarun2
 
 Rarun2 is a tool allowing to setup a specified execution environment - redefine stdin/stdout, pipes,
-change the environment variables, etc.
+change the environment variables and other useful settings.
 
 ```
 $ rarun2 -h


### PR DESCRIPTION
This is an attempt to remove all occurrences of "etc" which doesn't add information but leaves an unnecessary feeling of incompleteness to the reader.

I tried to avoid bullshit expressions like "plus a lot more" but probably failed in some place.