### PR TITLE
Reviewed and fixed code_anaylsis.md and esil.md

### DIFF
--- a/analysis/code_analysis.md
+++ b/analysis/code_analysis.md
@@ -2,13 +2,13 @@
 
 Code analysis is a common technique used to extract information from assembly code.
 
-Radare has different code analysis techniques implemented in the core and available in different commands.
+Radare2 has different code analysis techniques implemented in the core and available in different commands.
 
 As long as the whole functionalities of r2 are available with the API as well as using commands. This gives you the ability to implement your own analysis loops using any programming language, even with r2 oneliners, shellscripts, or analysis or core native plugins.
 
 The analysis will show up the internal data structures to identify basic blocks, function trees and to extract opcode-level information.
 
-The most common radare2 analysis command sequence is `aa`, which stands for "analyze all". That all is refering to all symbols and entrypoints. If your binary is stripped you will need to use other commands like aaa, aab, aar, aac or so.
+The most common radare2 analysis command sequence is `aa`, which stands for "analyze all". That all is referring to all symbols and entry-points. If your binary is stripped you will need to use other commands like `aaa`, `aab`, `aar`, `aac` or so.
 
 Take some time to understand what each command does and the results after running them to find the best one for your needs.
 
@@ -65,8 +65,8 @@ Take some time to understand what each command does and the results after runnin
 ```
 
 In this example, we analyze the whole file (`aa`) and then print disassembly of the `main()` function (`pdf`).
-The `aa` command belongs to the family of autoanalysis commands and performs only the most basic
-autoanalysis steps. In radare2 there are many different types of the autoanalysis commands with a
+The `aa` command belongs to the family of auto analysis commands and performs only the most basic
+auto analysis steps. In radare2 there are many different types of the auto analysis commands with a
 different analysis depth, including partial emulation: `aa`, `aaa`, `aab`, `aaaa`, ...
 There is also a mapping of those commands to the r2 CLI options: `r2 -A`, `r2 -AA`, and so on.
 
@@ -110,14 +110,13 @@ function or perform completely manual one.
 | afx                      list function references
 ```
 
-One of the most challenging tasks while performing a function analysis - merge, crop or resize.
-As with other analysis commands you have two ways - semi-automatic and totally manual one.
-For the semi-automatic, you can use `afm <function name>` to merge current function with
-the function specified, `aff` to readjust function after analysis changes or function edits,
-`afu <address>` to do the resize and analysis of the current function until specified address.
+Some of the most challenging tasks while performing a function analysis are merge, crop and resize.
+As with other analysis commands you have two modes: semi-automatic and manual.
+For the semi-automatic, you can use `afm <function name>` to merge the current function with
+the one specified by name as an argument, `aff` to readjust the function after analysis changes or function edits,
+`afu <address>` to do the resize and analysis of the current function until the specified address.
 
-Apart from those semi-automatic ways to edit/analyze the function, you can create it in
-complete manual mode with `af+` command and edit basic blocks of it using `afb` commands.
+Apart from those semi-automatic ways to edit/analyze the function, you can hand craft it in the manual mode with `af+` command and edit basic blocks of it using `afb` commands.
 Before changing the basic blocks of the function it is recommended to check the already presented ones:
 
 ```
@@ -130,7 +129,7 @@ Before changing the basic blocks of the function it is recommended to check the 
 0x00003ba8 0x00003bf9 00:0000 81
 ```
 
-There are two very important commands: `afc` and `afB`. The latter is a must-know command for some platforms like ARM. It provides a way to change the "bitness" of the particular function. Basically, allowing to select between ARM and Thumb modes.
+There are two very important commands for this: `afc` and `afB`. The latter is a must-know command for some platforms like ARM. It provides a way to change the "bitness" of the particular function. Basically, allowing to select between ARM and Thumb modes.
 
 `afc` on the other side, allows to manually specify function calling convention. You can find more information on its usage in [calling_conventions](calling_conventions.md).
 
@@ -199,7 +198,7 @@ push rbp
 mov rbp, rsp
 ```
 
-on x86_64 platform. It should be specified _before_ any analysis commands.
+on x86\_64 platform. It should be specified _before_ any analysis commands.
 
 ## Configuration
 
@@ -226,7 +225,7 @@ In addition to those we can also set `anal.ijmp` to follow the indirect jumps, c
 sequences at a function beginning.
 
 For now, radare2 also allows you to change the maximum basic block size with `anal.bb.maxsize` option
-. The default value just works in most use cases, but it's useful to increase that for example when 
+. The default value just works in most use cases, but it's useful to increase that for example when
 dealing with obfuscated code. Beware that some of basic blocks
 control options may disappear in the future in favor of more automated ways to set those.
 
@@ -237,7 +236,7 @@ binaries for embedded systems, it is often a case. Thus - this option.
 ### Reference control
 
 The most crucial options that change the analysis results drastically. Sometimes some can be
-disabled to save the time and memory when analysing big binaries.
+disabled to save the time and memory when analyzing big binaries.
 
 - `anal.jmpref` - to allow references creation for unconditional jumps
 - `anal.cjmpref` - same, but for conditional jumps
@@ -271,8 +270,8 @@ Two more options can affect the jump tables analysis results too:
 
 ### Platform specific controls
 
-There are two common problems when analysing embedded targets: ARM/Thumb detection and MIPS GP
-value. In case of ARM binaries radare2 supports some autodetection of ARM/Thumb mode switches, but
+There are two common problems when analyzing embedded targets: ARM/Thumb detection and MIPS GP
+value. In case of ARM binaries radare2 supports some auto-detection of ARM/Thumb mode switches, but
 beware that it uses partial ESIL emulation, thus slowing the analysis process. If you will not
 like the results, particular functions' mode can be overridden with `afB` command.
 
@@ -302,7 +301,7 @@ This mode allows you to see the disassembly of each node separately, just naviga
 
 It is not an uncommon case that analysis results are not perfect even after you tried every single
 configuration option. This is where the "analysis hints" radare2 mechanism comes in. It allows
-to override some basic opcode or metainformation properties, or even to rewrite the whole opcode
+to override some basic opcode or meta-information properties, or even to rewrite the whole opcode
 string. These commands are located under `ah` namespace:
 
 ```

--- a/disassembling/esil.md
+++ b/disassembling/esil.md
@@ -1,6 +1,6 @@
 # ESIL
 
-ESIL stands for 'Evaluable Strings Intermediate Language'. It aims to describe a [Forth](https://en.wikipedia.org/wiki/Forth_(programming_language) )-like representation for every target CPU opcode semantics. ESIL representations can be evaluated (interpreted) in order to emulate individual instructions. Each command of an ESIL expression is separated by a comma. Its virtual machine can be described as this:
+ESIL stands for 'Evaluable Strings Intermediate Language'. It aims to describe a [Forth](https://en.wikipedia.org/wiki/Forth_(programming_language)-like representation for every target CPU opcode semantics. ESIL representations can be evaluated (interpreted) in order to emulate individual instructions. Each command of an ESIL expression is separated by a comma. Its virtual machine can be described as this:
 ```
    while ((word=haveCommand())) {
      if (word.isOperator()) {
@@ -25,9 +25,9 @@ esp -= 4
 We can see that this corresponds to the x86 instruction `push ebp`! Isn't that cool?
 The aim is to be able to express most of the common operations performed by CPUs, like binary arithmetic operations, memory loads and stores, processing syscalls. This way if we can transform the instructions to ESIL we can see what a program does while it is running even for the most cryptic architectures you definitely don't have a device to debug on for.
 
-## Use ESIL
+## Using ESIL
 
-Using visual mode is great to inspect the esil evaluations.
+r2's visual mode is great to inspect the ESIL evaluations.
 
 There are 2 environment variables that are important for watching what a program does:
 ```
@@ -36,7 +36,7 @@ There are 2 environment variables that are important for watching what a program
 [0x00000000]> e asm.emu.str = true  # for version 2.3 and earlier
 ```
 
-`asm.emu` tells r2 if you want ESIL information to be displayed. If it is set to true you will see comments appear to the right of your disassembly that tell you how the contents of registers and memory addresses are changed by the current instruction. For example if you have an instruction that subtracts a value from a register it tells you what the value was before and what it becomes after. This is super useful so you don't have to sit there yourself and track which value goes where.
+`asm.emu` tells r2 if you want ESIL information to be displayed. If it is set to true, you will see comments appear to the right of your disassembly that tell you how the contents of registers and memory addresses are changed by the current instruction. For example, if you have an instruction that subtracts a value from a register it tells you what the value was before and what it becomes after. This is super useful so you don't have to sit there yourself and track which value goes where.
 
 One problem with this is that it is a lot of information to take in at once and sometimes you simply don't need it. r2 has a nice compromise for this. That is what the `asm.emu.str` variable is for (`asm.emustr` on 2.2 and earlier). Instead of this super verbose output with every register value, this only adds really useful information to the output, e.g., strings that are found at addresses a program uses or whether a jump is likely to be taken or not.
 
@@ -80,7 +80,7 @@ ADDR BREAK
 [0x00001019]>
 ```
 
-* "ar" : Show/modify ESIL registry
+* "ar" : Show/modify ESIL registry.
 
 ```
 [0x00001ec7]> ar r_00 = 0x1035
@@ -148,7 +148,7 @@ TODO | | To Do | Stops execution<br> (reason: ESIL expression not completed) | T
 
 ### ESIL Flags
 
-ESIL VM has an internal state flags that are read only and can be used to export those values to the underlying target CPU flags. It is because the ESIL VM always calculates all flag changes, while target CPUs only update flags under certain conditions or at specific instructions.
+ESIL VM has an internal state flags that are read-only and can be used to export those values to the underlying target CPU flags. It is because the ESIL VM always calculates all flag changes, while target CPUs only update flags under certain conditions or at specific instructions.
 
 Internal flags are prefixed with `$` character.
 
@@ -176,8 +176,6 @@ xor eax, eax    ->    0,eax,=,1,zf,=
 Memory access is defined by brackets operation:
 ```
 mov eax, [0x80480]   ->   0x80480,[],eax,=
-
-
 ```
 Default operand size is determined by size of operation destination.
 ```
@@ -209,7 +207,7 @@ Syscalls need special treatment. They are indicated by '$' at the beginning of a
 
 ## Arguments Order for Non-associative Operations
 
-As discussed on IRC, current implementation works like this:
+As discussed on IRC, the current implementation works like this:
 
 ```
 a,b,-      b - a
@@ -221,7 +219,7 @@ This approach is more readable, but it is less stack-friendly.
 
 NOPs are represented as empty strings. As it was said previously, syscalls are marked by '$' command. For example, '0x80,$'. It delegates emulation from the ESIL machine to a callback which implements syscalls for a specific OS/kernel.
 
-Traps are implemented with the `<code>,TRAP` command. They are used to throw exceptions for invalid instructions, division by zero, memory read error, or any other needed by specific architectures.
+Traps are implemented with the `TRAP` command. They are used to throw exceptions for invalid instructions, division by zero, memory read error, or any other needed by specific architectures.
 
 ### Quick Analysis
 
@@ -265,7 +263,7 @@ Properties of the VM variables:
 
 3. Register names have no specific syntax. They are just strings.
 
-4. Numbers can be specified in any base supported by RNum (dec, hex, oct, binary ...)
+4. Numbers can be specified in any base supported by RNum (dec, hex, oct, binary ...).
 
 5. Each ESIL backend should have an associated RReg profile to describe the ESIL register specs.
 
@@ -276,7 +274,7 @@ What to do with them? What about bit arithmetics if use variables instead of reg
 ### Arithmetics
 
 1. ADD ("+")
-2. MUL ("*")
+2. MUL ("\*")
 3. SUB ("-")
 4. DIV ("/")
 5. MOD ("%")
@@ -293,9 +291,9 @@ What to do with them? What about bit arithmetics if use variables instead of reg
 7. ROR  ">>>"
 8. NEG  "!"
 
-### Floating Point Support
+### Floating Point Unit Support
 
-At the moment of writing this, ESIL does not yet supports FPU. But you can implement support for unsupported instructions using r2pipe. Eventually we will get proper support for multimedia and floating point.
+At the moment of this writing, ESIL does not yet support FPU. But you can implement support for unsupported instructions using r2pipe. Eventually we will get proper support for multimedia and floating point.
 
 ### Handling x86 REP Prefix in ESIL
 
@@ -309,14 +307,14 @@ STACK    - dump stack contents to screen
 CLEAR    - clear stack
 ```
 
-#### Usage example:
+#### Usage Example:
 
 rep cmpsb
----------
+```
 cx,!,?{,BREAK,},esi,[1],edi,[1],==,?{,BREAK,},esi,++,edi,++,cx,--,0,GOTO
+```
 
-
-### Unimplemented/unhandled Instructions
+### Unimplemented/Unhandled Instructions
 
 Those are expressed with the 'TODO' command. They act as a 'BREAK', but displays a warning message describing that an instruction is not implemented and will not be emulated. For example:
 
@@ -359,7 +357,7 @@ fmulp ST(1), ST(0)      =>      TODO,fmulp ST(1),ST(0)
 
 ### Introspection
 
-To ease ESIL parsing we should have a way to express introspection expressions to extract data we want. For example, we may want to get the target address of a jump. The parser for ESIL expressions should offer API to make it possible to extract information by analyzing the expressions easily.
+To ease ESIL parsing we should have a way to express introspection expressions to extract the data that we want. For example, we may want to get the target address of a jump. The parser for ESIL expressions should offer an API to make it possible to extract information by analyzing the expressions easily.
 
 ```
 >  ao~esil,opcode
@@ -369,25 +367,25 @@ esil: 0x10000465a,rip,=
 We need a way to retrieve the numeric value of 'rip'. This is a very simple example, but there are more complex, like conditional ones. We need expressions to be able to get:
 
 - opcode type
-- destination of jump
+- destination of a jump
 - condition depends on
 - all regs modified (write)
 - all regs accessed (read)
 
 ### API HOOKS
 
-It is important for emulation to be able to setup hooks in parser, so we can extend it to implement analysis without having to change parser again and again. That is, every time an operation is about to be executed, a user hook is called. It can be used for example to determine if `RIP` is going to change, or if the instruction updates the stack.
-Later, we can split that callback into several ones to have an event-based analysis API that may be extended in js like this:
+It is important for emulation to be able to setup hooks in the parser, so we can extend it to implement analysis without having to change it again and again. That is, every time an operation is about to be executed, a user hook is called. It can be used for example to determine if `RIP` is going to change, or if the instruction updates the stack.
+Later, we can split that callback into several ones to have an event-based analysis API that may be extended in JavaScript like this:
 
 ```
 esil.on('regset', function(){..
 esil.on('syscall', function(){esil.regset('rip'
 ```
 
-For the API, see functions `hook_flag_read()`, `hook_execute()`, `hook_mem_read()`. A callback should return true if you want to override the action taken for a callback. For example, to deny memory reads in a region, or voiding memory writes, effectively making it read-only.
+For the API, see the functions `hook_flag_read()`, `hook_execute()` and `hook_mem_read()`. A callback should return true or 1 if you want to override the action that it takes. For example, to deny memory reads in a region, or voiding memory writes, effectively making it read-only.
 Return false or 0 if you want to trace ESIL expression parsing.
 
-Other operations that require bindings to external functionalities to work. In this case, `r_ref` and `r_io`. This must be defined when initializing the esil vm.
+Other operations require bindings to external functionalities to work. In this case, `r_ref` and `r_io`. This must be defined when initializing the ESIL VM.
 
 * Io Get/Set
   ```


### PR DESCRIPTION
Fixed typos, rewording, capitalization, puntuation, markdown escaping and some terms for consistency between chapters.