### PR TITLE
Fix load_bytes() signature on plugins/dev-bin.md

### DIFF
--- a/plugins/dev-bin.md
+++ b/plugins/dev-bin.md
@@ -41,9 +41,8 @@ uninstall:
 static int check(RBinFile *arch);
 static int check_bytes(const ut8 *buf, ut64 length);
 
-static void * load_bytes(RBinFile *arch, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
-	check_bytes (buf, sz);
-	return R_NOTNULL;
+static bool load_bytes(RBinFile *arch, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
+	return check_bytes (buf, sz);
 }
 
 


### PR DESCRIPTION
Fix needed because of https://github.com/radare/radare2/pull/11679 in r2.