### PR TITLE
Update python.md

### DIFF
--- a/plugins/python.md
+++ b/plugins/python.md
@@ -13,9 +13,9 @@ def mycpu(a):
     def assemble(s):
         return [1, 2, 3, 4]
 
-    def disassemble(buf):
+    def disassemble(memview, addr):
         try:
-            opcode = get_opcode(buf)
+            opcode = get_opcode(memview) # https://docs.python.org/3/library/stdtypes.html#memoryview
             opstr = optbl[opcode][1]
             return [4, opstr]
         except:
@@ -52,7 +52,7 @@ def mycpu_anal(a):
 		"gpr	pc	.32	28	0\n"
         return profile
 
-    def op(buf, len, pc):
+    def op(memview, pc):
 		analop = {
             "type" : R.R_ANAL_OP_TYPE_NULL,
             "cycles" : 0,
@@ -65,7 +65,7 @@ def mycpu_anal(a):
             "esil" : "",
         }
         try:
-            opcode = get_opcode(buf)
+            opcode = get_opcode(memview) # https://docs.python.org/3/library/stdtypes.html#memoryview
             esilstr = optbl[opcode][2]
             if optbl[opcode][0] == "J": # it's jump
                 analop["type"] = R.R_ANAL_OP_TYPE_JMP


### PR DESCRIPTION
As per https://github.com/radare/radare2-bindings/pull/213, the `disassemble` and `op` functions now receive a `memoryview` object instead of a regular `bytes` buffer. This is now denoted in the examples by the variable name `memview`. I added a link to the description of the `memoryview` object in Python's documentation, but in general, I believe a bit more detailed description of the various arguments is desirable in the examples (I'll gladly improve it when I have time).

Additionally, the arguments to both `disassemble` and `op` have changed recently (not part of the aforementioned PR), and this PR takes care of that, as well.