### PR TITLE
Windows compilation update

### DIFF
--- a/first_steps/windows_compilation.md
+++ b/first_steps/windows_compilation.md
@@ -79,36 +79,36 @@ Compiled binaries will be installed into the `dest` folder.
 
 1. Enter the Radare2 Conda environment
 2. Navigate to the root of the Radare2 sources (`cd radare2`)
-3. Initialize Visual Studio tooling by executing the command that matches the version of Visual Studio installed on your machine and the version of Radare2 you wish to install:
+3. Initialize Visual Studio tooling by executing the command below that matches the version of Visual Studio installed on your machine and the version of Radare2 you wish to install:
 
     * **Visual Studio 2015:**
 
-        Note: For the 64-bit version, change only the x86 at the end to x64 below.
+        Note: For the 64-bit version change only the `x86` at the very end of the command below to `x64`.
 
         `"%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86`
 
     * **Visual Studio 2017:**
 
-        Note 1: Change `Community` to either `Professional` or `Enterprise` below depending on the version installed.
+        Note 1: Change `Community` to either `Professional` or `Enterprise` in the command below depending on the version installed.
 
-        Note 2: Change `vcvars32.bat` to `vcvars64.bat` below for the 64-bit version.
+        Note 2: Change `vcvars32.bat` to `vcvars64.bat` in the command below for the 64-bit version.
 
          `"%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"`
 
     * **Visual Studio Preview:**
 
-        Note 1: Change `Community` to either `Professional` or `Enterprise` below depending on the version installed.
+        Note 1: Change `Community` to either `Professional` or `Enterprise` in the command below depending on the version installed.
 
-        Note 2: Change `vcvars32.bat` to `vcvars64.bat` below for the 64-bit version.
+        Note 2: Change `vcvars32.bat` to `vcvars64.bat` in the command below for the 64-bit version.
 
         `"%ProgramFiles(x86)%\Microsoft Visual Studio\Preview\Community\VC\Auxiliary\Build\vcvars32.bat"`
 
 
 4. Generate the build system with Meson:
 
-  Note 1: Change `debug` to `release` below depending on whether the latest or release version is desired.
+  Note 1: Change `debug` to `release` in the command below depending on whether the latest version or release version is desired.
 
-  Note 2: If you are using visual studio 2017, you can change `vs2015` to `vs2017`.
+  Note 2: If you are using visual studio 2017, you can change swap `vs2015` for `vs2017`.
 
   `meson build --buildtype debug --backend vs2015 --prefix %cd%\dest`
 
@@ -116,18 +116,18 @@ Compiled binaries will be installed into the `dest` folder.
 
 5. Start a build:
 
-    Note: Change `Debug` to `Release` below depending on the version desired.
+    Note: Change `Debug` to `Release` in the command below depending on the version desired.
 
     `msbuild build\radare2.sln /p:Configuration=Debug /m`
 
     The `/m[axcpucount]` switch creates one MSBuild worker process per logical processor on your machine. You can specify a numeric value (e.g. `/m:2`) to limit the number of worker processes if needed. (This should not be confused with the Visual C++ Compiler switch `/MP`.)
 
-    If you get an error with the 32-bit install that says something along the lines of `error MSB4126: The specified solution configuration "Debug|x86" is invalid.` Get around this by adding the following argument to the build command: `/p:Platform=Win32`
+    If you get an error with the 32-bit install that says something along the lines of `error MSB4126: The specified solution configuration "Debug|x86" is invalid.` Get around this by adding the following argument to the command: `/p:Platform=Win32`
 
 6. Install into your destination folder: `meson install -C build --no-rebuild`
 7. Check your Radare2 version: `dest\bin\radare2.exe -v`
 
-#### Check that Radare2 runs from all locations
+#### Check That Radare2 Runs From All Locations
 1. In the file explorer go to the folder Radare2 was just installed in.
 2. From this folder go to `dest` > `bin` and keep this window open.
 3. Go to System Properties: In the Windows search bar enter `sysdm.cpl`.

--- a/first_steps/windows_compilation.md
+++ b/first_steps/windows_compilation.md
@@ -73,30 +73,67 @@ Follow these steps to clone the Radare2 git repository.
 2. Clone the repository with `git clone https://github.com/radare/radare2.git`
 
 #### Compile Radare2 Code
-Follow these steps to compile a debug 32-bit (x86) version of Radare2. (If you want to build a 64-bit (x64) version of Radare2, replace all instances of `x86` with `x64`. Similarly, if you want to build a release version, replace all instances of `debug` with `release`.)
+Follow these steps to compile the Radare2 Code.
 
 Compiled binaries will be installed into the `dest` folder.
 
 1. Enter the Radare2 Conda environment
 2. Navigate to the root of the Radare2 sources (`cd radare2`)
-3. Initialize Visual Studio tooling by executing the command that matches the version of Visual Studio installed on your machine:
+3. Initialize Visual Studio tooling by executing the command that matches the version of Visual Studio installed on your machine and the version of Radare2 you wish to install:
 
-    * Visual Studio 2015:
-    `"%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86`
+    * **Visual Studio 2015:**
 
-    * Visual Studio 2017:
-    `"%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars32.bat"`
+        Note: For the 64-bit version, change only the x86 at the end to x64 below.
 
-    * Visual Studio Preview:
-    `"%ProgramFiles(x86)%\Microsoft Visual Studio\Preview\Enterprise\VC\Auxiliary\Build\vcvars32.bat"`
+        `"%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86`
 
-4. Generate the build system with Meson: `meson build --buildtype debug --backend vs2015 --prefix %cd%\dest`
-  
-    Meson currently requires `--prefix` to point to an absolute path. We use the %CD% pseudo-variable to get the absolute path to the current working directory.
+    * **Visual Studio 2017:**
 
-5. Start a build: `msbuild build\radare2.sln /p:Configuration=Debug /m`
-  
+        Note 1: Change `Community` to either `Professional` or `Enterprise` below depending on the version installed.
+
+        Note 2: Change `vcvars32.bat` to `vcvars64.bat` below for the 64-bit version.
+
+         `"%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"`
+
+    * **Visual Studio Preview:**
+
+        Note 1: Change `Community` to either `Professional` or `Enterprise` below depending on the version installed.
+
+        Note 2: Change `vcvars32.bat` to `vcvars64.bat` below for the 64-bit version.
+
+        `"%ProgramFiles(x86)%\Microsoft Visual Studio\Preview\Community\VC\Auxiliary\Build\vcvars32.bat"`
+
+
+4. Generate the build system with Meson:
+
+  Note 1: Change `debug` to `release` below depending on whether the latest or release version is desired.
+
+  Note 2: If you are using visual studio 2017, you can change `vs2015` to `vs2017`.
+
+  `meson build --buildtype debug --backend vs2015 --prefix %cd%\dest`
+
+  Meson currently requires `--prefix` to point to an absolute path. We use the %CD% pseudo-variable to get the absolute path to the current working directory.
+
+5. Start a build:
+
+    Note: Change `Debug` to `Release` below depending on the version desired.
+
+    `msbuild build\radare2.sln /p:Configuration=Debug /m`
+
     The `/m[axcpucount]` switch creates one MSBuild worker process per logical processor on your machine. You can specify a numeric value (e.g. `/m:2`) to limit the number of worker processes if needed. (This should not be confused with the Visual C++ Compiler switch `/MP`.)
+
+    If you get an error with the 32-bit install that says something along the lines of `error MSB4126: The specified solution configuration "Debug|x86" is invalid.` Get around this by adding the following argument to the build command: `/p:Platform=Win32`
 
 6. Install into your destination folder: `meson install -C build --no-rebuild`
 7. Check your Radare2 version: `dest\bin\radare2.exe -v`
+
+#### Check that Radare2 runs from all locations
+1. In the file explorer go to the folder Radare2 was just installed in.
+2. From this folder go to `dest` > `bin` and keep this window open.
+3. Go to System Properties: In the Windows search bar enter `sysdm.cpl`.
+4. Go to `Advanced > Environment Variables`.
+5. Click on the PATH variable and then click edit (if it exists within both the user and system variables, look at the user version).
+6. Ensure the file path displayed in the window left open is listed within the PATH variable. If it is not add it and click `ok`.
+7. Log out of your Windows session.
+8. Open up a new Windows Command Prompt: type `cmd` in the search bar. Ensure that the current path is not in the Radare2 folder.
+9. Check Radare2 version from Command Prompt Window: `radare2 -v`


### PR DESCRIPTION
Additional details to Windows compilation instructions.

Updated "Compile Radare2 Code" section and added "Check That Radare2 Runs From All Locations" section. This is due to various issues run into while installing the Windows version of Radare2 for Visual Studio Community 2017. 3 issues were kept in mind.

1. When running the build command `msbuild build\radare2.sln /p:Configuration=Debug /m` for the 32-bit install, the following error kept appearing: `error MSB4126: The specified solution configuration "Debug|x86" is invalid.` A fix is provided for this error.

1. After compiling and installing the program. The PATH variable was not updated on my system. This happened for multiple installs. To help with this, the `Check That Radare2 Runs From All Locations` section is added.

1. Some changes were made to make things more clear. For example, the original version says `replace all instances of x86 with x64` even though we are not supposed to change the `x86`  in `%ProgramFiles(x86)%`.