### PR TITLE
improve refcard search command /x

### DIFF
--- a/refcard/intro.md
+++ b/refcard/intro.md
@@ -14,13 +14,13 @@ around a binary and getting information about it.
 
 | Command                 | Description                      |
 |:------------------------|:---------------------------------|
-| s (tab)                 | Seek to a different place        |
-| x [nbytes]              | Hexdump of nbytes, $b by default |
-| aa                      | Auto analyze                     |
-| pdf@fcn(Tab)            | Disassemble function             |
-| f fcn(Tab)              | List functions                   |
-| f str(Tab)              | List strings                     |
-| fr [flagname] [newname] | Rename flag                      |
+| s (tab)                 | Seek to a different place        |
+| x [nbytes]              | Hexdump of nbytes, $b by default |
+| aa                      | Auto analyze                     |
+| pdf@fcn(Tab)            | Disassemble function             |
+| f fcn(Tab)              | List functions                   |
+| f str(Tab)              | List strings                     |
+| fr [flagname] [newname] | Rename flag                      |
 | psz [offset]~grep       | Print strings and grep for one   |
 | arf [flag]              | Find cross reference for a flag  |
 
@@ -140,9 +140,9 @@ where the `/` command may search for the given value.
 | /! ff          | Search for first occurrence not matching      |
 | /i foo         | Search for string ’foo’ ignoring case         |
 | /e /E.F/i      | Match regular expression                      |
-| /x ff0.23      | Search for hex string                         |
-| /x ff..33      | Search for hex string ignoring some nibbles   |
-| /x ff43 ffd0   | Search for hexpair with mask                  |
+| /x a1b2c3      | Search for bytes; spaces and uppercase nibbles are allowed, same as /x A1 B2 C3|
+| /x a1..c3      | Search for bytes ignoring some nibbles (auto-generates mask, in this example: ff00ff)|
+| /x a1b2:fff3   | Search for bytes with mask (specify individual bits)|
 | /d 101112      | Search for a deltified sequence of bytes      |
 | /!x 00         | Inverse hexa search (find first byte != 0x00) |
 | /c jmp [esp]   | Search for asm code (see search.asmstr)       |

--- a/refcard/radare2_rc.tex
+++ b/refcard/radare2_rc.tex
@@ -172,9 +172,9 @@
 \cm{/! ff}{search for first occurrence not matching}
 \cm{/i foo}{search for string 'foo' ignoring case}
 \cm{/e /E.F/i}{match regular expression}
-\cm{/x ff0.23}{search for hex string}
-\cm{/x ff..33}{search for hex string ignoring some nibbles}
-\cm{/x ff43 ffd0}{search for hexpair with mask}
+\cm{/x a1b2c3}{search for bytes, same as {\tt/x A1 B2 C3}}
+\cm{/x a1..c3}{search for bytes ignoring some nibbles}
+\cm{/x a1b2:fff3}{search for bytes with mask}
 \cm{/d 101112}{search for a deltified sequence of bytes}
 \cm{/!x 00}{inverse hexa search (find first byte != 0x00)}
 \cm{/c jmp [esp]}{search for asm code (see search.asmstr)}
@@ -206,7 +206,7 @@
 \cm{\dollar{}j}{jump address (jmp 0x10, jz 0x10 =$>$ 0x10)}
 \cm{\dollar{}f}{jump fail address (jz 0x10 =$>$ next instruction)}
 \cm{\dollar{}I}{number of instructions of current function}
-\cm{\dollar{}F}{current function size} 
+\cm{\dollar{}F}{current function size}
 \cm{\dollar{}Jn}{get nth jump of function}
 \cm{\dollar{}Cn}{get nth call of function}
 \cm{\dollar{}Dn}{get nth data reference in function}


### PR DESCRIPTION
plus some cleanup:
* 7 visually unchanged lines in refcard/intro.md contained special multi-byte space characters
* trimmed a trailing space in refcard/radare2_rc.tex